### PR TITLE
Update to README: Add Example of Binary Read: Required on Windows

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,7 +39,11 @@ Creating an HTML fax:
 
 Creating a PDF fax:
 
-    fax = OrderFax.new(:pdf).contains(File.read('/files/document.pdf').subject("test").to("+4923456123456")
+    fax = OrderFax.new(:pdf).contains(File.read('/files/document.pdf')).subject("test").to("+4923456123456")
+
+Creating a PDF fax on Windows (Force Binary Mode on File Read):
+
+    fax = OrderFax.new(:pdf).contains(File.open('/files/document.pdf','rb') {|io| io.read}).subject("test").to("+4923456123456")
 
 It is possible to specify more than one receipent:
 


### PR DESCRIPTION
Minor updates to README showing a new example.  This new example worked for me on Windows.

Add another example of sending a PDF file to Interfax service when
called on a Windows computer.  Need to explicitly set binary mode

Fix missing paraenthesis.
