### PR TITLE
Add support to set CSID on sending a fax

### DIFF
--- a/lib/interfax/base.rb
+++ b/lib/interfax/base.rb
@@ -58,6 +58,7 @@ module Interfax
       @recipients = nil
       @subject = "Change me"
       @retries = "0"
+      @csid = nil
     end
     
     def contains(content)
@@ -85,6 +86,12 @@ module Interfax
       self
     end
     
+
+    #Sender CSID (up to 20 characters). If not provided, user's default CSID is used.
+    def csid=(csid_string)
+        @csid = csid_string.to_s[0,20]
+    end
+    
     def summary
       { 
         :fax_numbers => @recipients, 
@@ -97,7 +104,8 @@ module Interfax
     end
     
     def deliver
-      result = SOAP::WSDLDriverFactory.new("https://ws.interfax.net/dfs.asmx?WSDL").create_rpc_driver.SendfaxEx_2(
+
+      options = {
         :Username => @username,
         :Password => @password,
         :FileTypes => @type,
@@ -111,7 +119,14 @@ module Interfax
         :PageOrientation => 'Portrait',
         :IsHighResolution => 'true',
         :IsFineRendering => 'false'
-      )
+      }
+
+        
+      #option settings
+      options[:CSID] = @csid if @csid
+
+      result = SOAP::WSDLDriverFactory.new("https://ws.interfax.net/dfs.asmx?WSDL").create_rpc_driver.SendfaxEx_2(options)
+
       result ? result.sendfaxEx_2Result : nil
     end
     


### PR DESCRIPTION
Would you mind taking a look at my approach for setting an option CSID string?  I wasn't sure on how you would prefer to see this new setter for CSID.
## I tested this (sending with and without setting the CSID with my Interfax account) but was not sure how to show you my test.

Add support to set a custom CSID string on a fax-by-fax basis.  If
not set, CSID will be pulled from the default Interfax user settings.
