### PR TITLE
Fix bug in `multipart/mixed` bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.1]
+
+Fix bug in `multipart/mixed` bodies.
+
+Resolve a bug where the `multipart/mixed` boundary and the end of a request body wasn't properly closed.
+
+Upgrading to this version is highly recommended.
+
 ## [1.1.0]
 
 Add PDF support when saving files.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    interfax (1.1.0)
+    interfax (1.1.1)
       mimemagic (~> 0.3.1)
 
 GEM
@@ -32,4 +32,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.16.0

--- a/lib/interfax/outbound/delivery.rb
+++ b/lib/interfax/outbound/delivery.rb
@@ -47,6 +47,6 @@ class InterFAX::Outbound::Delivery
   def body_for(files)
     files.map do |file|
       "--#{BOUNDARY}\r\n#{file.header}\r\n\r\n#{file.body}\r\n"
-    end.join + "--#{BOUNDARY}\r\n"
+    end.join + "--#{BOUNDARY}--\r\n"
   end
 end

--- a/lib/interfax/version.rb
+++ b/lib/interfax/version.rb
@@ -1,3 +1,3 @@
 module InterFAX
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/spec/outbound/delivery_spec.rb
+++ b/spec/outbound/delivery_spec.rb
@@ -13,7 +13,7 @@ describe 'InterFAX::Outbound::Delivery' do
       params == {faxNumber: '11111'} &&
       valid_keys == InterFAX::Outbound::Delivery::VALID_KEYS &&
       headers == InterFAX::Outbound::Delivery::HEADERS &&
-      body.include?(InterFAX::Outbound::Delivery::BOUNDARY)
+      body.include?("--#{InterFAX::Outbound::Delivery::BOUNDARY}--")
     end
     result = @delivery.deliver faxNumber: '11111', file: './spec/test.pdf'
     result.id.must_equal '123'


### PR DESCRIPTION
Resolve a bug where the `multipart/mixed` boundary and the end of a request body wasn't properly closed.

Upgrading to this version is highly recommended.