### PR TITLE
New Versions of Ruby do not include ostruct by default

### DIFF
--- a/lib/interfax/object.rb
+++ b/lib/interfax/object.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 class InterFAX::Object < OpenStruct
   def attributes
     hash = to_h


### PR DESCRIPTION
This pull request includes a minor change to the `lib/interfax/object.rb` file. The change imports the `ostruct` library to ensure the `OpenStruct` class is available for use.

* [`lib/interfax/object.rb`](diffhunk://#diff-f1dbd6c02fec8b36f86cbcb3818dde095aa69012435a59daffc9e924c01f511bR1-R2): Added `require "ostruct"` to import the `ostruct` library.